### PR TITLE
Make it work with python3

### DIFF
--- a/postgresql_query.py
+++ b/postgresql_query.py
@@ -102,7 +102,7 @@ def print_data(pg, conf):
         if "per_db" in q and q["per_db"]:
             # Have to run queries for all fetch dbs
             results = pg.per_db_query(query)
-            for (dbname, result) in results.iteritems():
+            for (dbname, result) in results.items():
                 to_print = to_print + format_results(result, dbname=dbname,
                                                      measurement=measurement,
                                                      tagvalue=tagvalue)


### PR DESCRIPTION
This only removes the call to `iteritems()` which no longer exists in Python3. This has several effects:

* It will work in both Python-2 and Python-3
* In Python-2 all items are materialised in memory because `items()` returns a list. So this will increase memory usage in Python-2 only. Python-3 will remain identical because in Python-3 `items()` behaves like `iteritems()`. This is negligable because the queries don't return that much data anyway.

This covers #3 